### PR TITLE
Avoid copying any strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,13 @@ originaly written in JavaScript by Mr. Taku Kudo.
 
 ## Usage
 
-```julia
+```jl
 using TinySegmenter
 
 join(tokenize("私の名前は中野です"), " | ")
 # "私 | の | 名前 | は | 中野 | です"
 ```
+
+The return value of `tokenize` is an array of substrings of the string input,
+giving the locations of the tokens in the text.  (Substrings are represented
+by the `SubString` Julia type.)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,10 +4,12 @@ using Base.Test
 @test tokenize("私の名前は中野です") == ["私", "の", "名前", "は", "中野", "です"]
 @test tokenize("TinySegmenterは25kBで書かれています。")　== ["TinySegmenter", "は", "2", "5", "kB", "で", "書か", "れ", "て", "い", "ます", "。"]
 @test tokenize("") == []
-#@test _ctype('一') == 'M'
-#@test _ctype('〆') == 'H'
-#@test _ctype('名') == 'H'
-#@test _ctype('あ') == 'I'
-#@test _ctype('ア') == 'K'
-#@test _ctype('Ｚ') == 'A'
-#@test _ctype('９') == 'N'
+
+import TinySegmenter.ctype
+@test ctype('一') == 'M'
+@test ctype('〆') == 'H'
+@test ctype('名') == 'H'
+@test ctype('あ') == 'I'
+@test ctype('ア') == 'K'
+@test ctype('Ｚ') == 'A'
+@test ctype('９') == 'N'


### PR DESCRIPTION
This PR adds two commits in order to avoid copying any strings.
- Instead of making a copy `segment` of all the characters in `text`, and an array `ctype` of character types, it updates `w1,w2,w3,w4,w5,w6` on the fly, during a single pass over `text`.
- Instead of returning array of `UTF8String`, it returns an array of `SubString`.   A `SubString`, in Julia, is a string type (a subtype of `AbstractString`) that is essentially a pointer to a segment of another string.  This allows it to refer to a block of `text` without actually copying it.   It has the additional benefit that the `SubString` contains the information about _where_ in `text` the token is located, if you want to go in the reverse direction.

Together, these speed things up only slightly, but they do significantly decrease memory usage.
